### PR TITLE
Refactor: 아카데미 조회 응답 내 `activities` 필드명을 `academies`로 변경

### DIFF
--- a/src/main/java/kr/tennispark/activity/user/presentation/controller/UserActivityCertificationController.java
+++ b/src/main/java/kr/tennispark/activity/user/presentation/controller/UserActivityCertificationController.java
@@ -2,7 +2,7 @@ package kr.tennispark.activity.user.presentation.controller;
 
 import jakarta.validation.Valid;
 import kr.tennispark.activity.user.application.service.ActivityCertificationService;
-import kr.tennispark.activity.user.presentation.dto.response.PostCertificationRequest;
+import kr.tennispark.activity.user.presentation.dto.request.PostCertificationRequest;
 import kr.tennispark.common.annotation.LoginMember;
 import kr.tennispark.common.utils.ApiUtils;
 import kr.tennispark.common.utils.ApiUtils.ApiResult;

--- a/src/main/java/kr/tennispark/activity/user/presentation/dto/request/PostCertificationRequest.java
+++ b/src/main/java/kr/tennispark/activity/user/presentation/dto/request/PostCertificationRequest.java
@@ -1,4 +1,4 @@
-package kr.tennispark.activity.user.presentation.dto.response;
+package kr.tennispark.activity.user.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/kr/tennispark/activity/user/presentation/dto/response/GetAcademyResponse.java
+++ b/src/main/java/kr/tennispark/activity/user/presentation/dto/response/GetAcademyResponse.java
@@ -3,7 +3,7 @@ package kr.tennispark.activity.user.presentation.dto.response;
 import java.util.List;
 import kr.tennispark.activity.common.domain.Activity;
 
-public record GetAcademyResponse(List<AcademyDTO> activities) {
+public record GetAcademyResponse(List<AcademyDTO> academies) {
 
     public static GetAcademyResponse of(List<Activity> activities) {
         List<AcademyDTO> dtos = activities.stream()


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #48 

## 🔧 작업 내용
- 아카데미 조회 응답 내 `activities` 필드명을 `academies`로 변경

## 💬 기타 사항
