### PR TITLE
[Feature] 매치 포인트 랭킹 로직 작성

### DIFF
--- a/src/main/java/kr/tennispark/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/tennispark/common/exception/GlobalExceptionHandler.java
@@ -103,4 +103,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleBadQrCreateException(BadQrCreateException e) {
         return ResponseEntity.status(e.status()).body(ApiUtils.error(e.status(), e.getMessage()));
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResult<?>> handleIllegalState(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiUtils.error(HttpStatus.INTERNAL_SERVER_ERROR, "요청 처리 중 오류가 발생했습니다."));
+    }
 }

--- a/src/main/java/kr/tennispark/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/tennispark/common/exception/GlobalExceptionHandler.java
@@ -91,7 +91,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleJwtException(JwtException ex) {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body("유효하지 않은 토큰입니다.");
+                .body(ApiUtils.error(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."));
     }
 
     @ExceptionHandler(FailToCreateQRPayloadException.class)

--- a/src/main/java/kr/tennispark/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/tennispark/common/exception/GlobalExceptionHandler.java
@@ -106,7 +106,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ApiResult<?>> handleIllegalState(IllegalStateException e) {
+        log.error("시스템 상태 오류: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiUtils.error(HttpStatus.INTERNAL_SERVER_ERROR, "요청 처리 중 오류가 발생했습니다."));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResult<?>> handleUnexpected(Exception e) {
+        log.error("처리되지 않은 예외 발생", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiUtils.error(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/kr/tennispark/match/admin/application/impl/MatchResultServiceImpl.java
+++ b/src/main/java/kr/tennispark/match/admin/application/impl/MatchResultServiceImpl.java
@@ -13,6 +13,7 @@ import kr.tennispark.match.common.domain.entity.association.MatchParticipation;
 import kr.tennispark.match.common.domain.entity.enums.MatchOutcome;
 import kr.tennispark.match.common.domain.entity.exception.InvalidMatchResultException;
 import kr.tennispark.members.common.domain.entity.Member;
+import kr.tennispark.members.common.domain.exception.NoSuchMemberException;
 import kr.tennispark.members.user.application.service.MemberService;
 import kr.tennispark.members.user.infrastructure.repository.MemberRepository;
 import kr.tennispark.point.common.application.service.PointService;
@@ -93,7 +94,13 @@ public class MatchResultServiceImpl implements MatchResultService {
 
 
     private List<Member> fetchMembersByIds(List<Long> ids) {
-        return memberRepository.findAllById(ids);
+        List<Member> members = memberRepository.findAllById(ids);
+
+        if (members.size() != ids.size()) {
+            throw new NoSuchMemberException();
+        }
+
+        return members;
     }
 
     private void validateMemberDuplication(List<Long> teamAIds, List<Long> teamBIds) {

--- a/src/main/java/kr/tennispark/match/common/application/dto/MatchPointIncreasedEvent.java
+++ b/src/main/java/kr/tennispark/match/common/application/dto/MatchPointIncreasedEvent.java
@@ -1,0 +1,6 @@
+package kr.tennispark.match.common.application.dto;
+
+public record MatchPointIncreasedEvent(
+        Long memberId,
+        int point) {
+}

--- a/src/main/java/kr/tennispark/match/common/application/service/MatchPointRankingEventHandler.java
+++ b/src/main/java/kr/tennispark/match/common/application/service/MatchPointRankingEventHandler.java
@@ -1,0 +1,20 @@
+package kr.tennispark.match.common.application.service;
+
+import kr.tennispark.match.common.application.dto.MatchPointIncreasedEvent;
+import kr.tennispark.match.common.infrastructure.repository.MatchPointRankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MatchPointRankingEventHandler {
+
+    private final MatchPointRankingRepository rankingRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MatchPointIncreasedEvent event) {
+        rankingRepository.increaseScore(event.memberId(), event.point());
+    }
+}

--- a/src/main/java/kr/tennispark/match/common/infrastructure/repository/MatchPointRankingRepository.java
+++ b/src/main/java/kr/tennispark/match/common/infrastructure/repository/MatchPointRankingRepository.java
@@ -1,0 +1,7 @@
+package kr.tennispark.match.common.infrastructure.repository;
+
+public interface MatchPointRankingRepository {
+    void increaseScore(Long memberId, int delta);
+
+    Long getRank(Long memberId);
+}

--- a/src/main/java/kr/tennispark/match/common/infrastructure/repository/impl/MatchPointRankingRedisRepository.java
+++ b/src/main/java/kr/tennispark/match/common/infrastructure/repository/impl/MatchPointRankingRedisRepository.java
@@ -1,0 +1,25 @@
+package kr.tennispark.match.common.infrastructure.repository.impl;
+
+import kr.tennispark.match.common.infrastructure.repository.MatchPointRankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MatchPointRankingRedisRepository implements MatchPointRankingRepository {
+
+    private static final String KEY = "ranking:member:matchPoint";
+    private final StringRedisTemplate redis;
+
+    @Override
+    public void increaseScore(Long memberId, int delta) {
+        redis.opsForZSet().incrementScore(KEY, memberId.toString(), delta);
+    }
+
+    @Override
+    public Long getRank(Long memberId) {
+        Long rank = redis.opsForZSet().reverseRank(KEY, memberId.toString());
+        return rank == null ? null : rank + 1;
+    }
+}

--- a/src/main/java/kr/tennispark/members/admin/application/MemberAdminUseCaseImpl.java
+++ b/src/main/java/kr/tennispark/members/admin/application/MemberAdminUseCaseImpl.java
@@ -4,8 +4,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import kr.tennispark.activity.admin.infrastructure.repository.ActivityRepository;
 import kr.tennispark.activity.user.infrastructure.repository.UserActivityApplicationRepository;
+import kr.tennispark.match.common.infrastructure.repository.MatchPointRankingRepository;
 import kr.tennispark.members.admin.presentation.dto.response.GetMemberListResponseDTO;
 import kr.tennispark.members.admin.presentation.dto.response.GetMonthlyMemberActivityStatsResponseDTO;
 import kr.tennispark.members.admin.presentation.dto.response.GetOverallMemberStatsResponseDTO;
@@ -26,6 +29,7 @@ public class MemberAdminUseCaseImpl implements MemberAdminUseCase {
     private final PointHistoryRepository pointHistoryRepository;
     private final UserActivityApplicationRepository activityApplicationRepository;
     private final ActivityRepository activityRepository;
+    private final MatchPointRankingRepository rankingRepository;
 
     @Override
     public GetMonthlyMemberActivityStatsResponseDTO getMonthlyActivityStats(LocalDate from, LocalDate to) {
@@ -66,7 +70,13 @@ public class MemberAdminUseCaseImpl implements MemberAdminUseCase {
     @Override
     public GetMemberListResponseDTO getMemberList(String name) {
         List<Member> members = memberRepository.findByNameContaining(name);
-        return GetMemberListResponseDTO.of(members);
+        Map<Long, Integer> rankMap = members.stream()
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        m -> rankingRepository.getRank(m.getId()).intValue()
+                ));
+
+        return GetMemberListResponseDTO.of(members, rankMap);
     }
 
     // ===== 내부 계산 메서드 =====

--- a/src/main/java/kr/tennispark/members/admin/presentation/dto/response/GetMemberListResponseDTO.java
+++ b/src/main/java/kr/tennispark/members/admin/presentation/dto/response/GetMemberListResponseDTO.java
@@ -1,24 +1,17 @@
 package kr.tennispark.members.admin.presentation.dto.response;
 
 import java.util.List;
+import java.util.Map;
 import kr.tennispark.members.common.domain.entity.Member;
 import kr.tennispark.members.common.domain.entity.enums.MemberShipType;
 
 public record GetMemberListResponseDTO(List<MemberDTO> members) {
 
-    public static GetMemberListResponseDTO of(List<Member> members) {
-        List<MemberDTO> memberDTOs = members.stream()
-                .map(member -> MemberDTO.of(
-                        member.getId(),
-                        member.getPhone().getNumber(),
-                        member.getName(),
-                        member.getTennisCareer(),
-                        member.getYear(),
-                        member.getInstagramId(),
-                        member.getMemberShipType()
-                ))
+    public static GetMemberListResponseDTO of(List<Member> members, Map<Long, Integer> ranks) {
+        List<MemberDTO> dtos = members.stream()
+                .map(member -> MemberDTO.of(member, ranks.getOrDefault(member.getId(), 0)))
                 .toList();
-        return new GetMemberListResponseDTO(memberDTOs);
+        return new GetMemberListResponseDTO(dtos);
     }
 
     public record MemberDTO(
@@ -26,13 +19,20 @@ public record GetMemberListResponseDTO(List<MemberDTO> members) {
             String phoneNumber,
             String name,
             String tennisCareer,
-            int year,
-            String instagramId,
+            int matchPoint,
+            int ranking,
             MemberShipType memberShipType
     ) {
-        public static MemberDTO of(Long memberId, String phoneNumber, String name, String tennisCareer, int year,
-                                   String instagramId, MemberShipType memberShipType) {
-            return new MemberDTO(memberId, phoneNumber, name, tennisCareer, year, instagramId, memberShipType);
+        public static MemberDTO of(Member member, int ranking) {
+            return new MemberDTO(
+                    member.getId(),
+                    member.getPhone().getNumber(),
+                    member.getName(),
+                    member.getTennisCareer(),
+                    member.getMatchPoint(),
+                    ranking,
+                    member.getMemberShipType()
+            );
         }
     }
 }

--- a/src/main/java/kr/tennispark/members/common/domain/entity/Member.java
+++ b/src/main/java/kr/tennispark/members/common/domain/entity/Member.java
@@ -14,12 +14,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import kr.tennispark.common.domain.BaseEntity;
-import kr.tennispark.point.common.domain.entity.Point;
 import kr.tennispark.members.common.domain.entity.enums.Gender;
 import kr.tennispark.members.common.domain.entity.enums.MemberShipType;
 import kr.tennispark.members.common.domain.entity.enums.RegistrationSource;
 import kr.tennispark.members.common.domain.entity.vo.Phone;
 import kr.tennispark.members.common.domain.exception.InvalidMemberException;
+import kr.tennispark.point.common.domain.entity.Point;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -59,6 +59,7 @@ public class Member extends BaseEntity {
     private Point point;
 
     @Column(nullable = false)
+    @ColumnDefault("0")
     private Integer matchPoint = 0;
 
     @Column(nullable = false)

--- a/src/main/java/kr/tennispark/point/common/domain/entity/Point.java
+++ b/src/main/java/kr/tennispark/point/common/domain/entity/Point.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -25,7 +26,8 @@ public class Point extends BaseEntity {
     private Member member;
 
     @Column(nullable = false)
-    private Integer totalPoint;
+    @ColumnDefault("0")
+    private Integer totalPoint = 0;
 
     public static Point of(Member member) {
         return new Point(member, 0);


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
closed: #42 
closed: #54 
## 🔧 작업 내용
- 레디스 ZSet으로 매치 포인트 랭킹 저장 구조 구현
- 경기 기록 등록 시 레디스 랭킹에 자동 반영
- 회원정보 조회 시 인스타 id+나이 대신 매치 포인트 + 순위 필드 반환
## 💬 기타 사항
- 포인트, match point db 디폴트값 적용
- 경기기록 등록 시 유효한 memberId인지 확인 로직 추가