### PR TITLE
[Fix] 월 별 통계 쿼리 조회 시, 항상 하나의 회원만 조회 하도록 쿼리 수정

### DIFF
--- a/src/main/java/kr/tennispark/point/user/infrastrurcture/repository/PointHistoryRepository.java
+++ b/src/main/java/kr/tennispark/point/user/infrastrurcture/repository/PointHistoryRepository.java
@@ -27,6 +27,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             AND ph.amount > 0 
             GROUP BY ph.point.member 
             ORDER BY SUM(ph.amount) DESC
+            LIMIT 1
             """)
     Optional<Member> findTopEarner(LocalDateTime start, LocalDateTime end);
 
@@ -36,7 +37,8 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             WHERE ph.createdAt BETWEEN :start AND :end 
             AND ph.amount < 0 
             GROUP BY ph.point.member 
-            ORDER BY SUM(ph.amount) ASC
+            ORDER BY SUM(ph.amount) ASC 
+            LIMIT 1
             """)
     Optional<Member> findTopSpender(LocalDateTime start, LocalDateTime end);
 


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #80 

## 🔧 작업 내용
- 월 별 통계 쿼리 조회 시, 항상 하나의 회원만 조회 하도록 쿼리 수정

## 💬 기타 사항
