### PR TITLE
[Deploy] 월 별 통계 쿼리 조회 시, 항상 하나의 회원만 조회 하도록 쿼리 수정

### DIFF
--- a/src/main/java/kr/tennispark/advertisement/admin/presentation/dto/response/GetAdvertisementResponseDTO.java
+++ b/src/main/java/kr/tennispark/advertisement/admin/presentation/dto/response/GetAdvertisementResponseDTO.java
@@ -8,7 +8,7 @@ public record GetAdvertisementResponseDTO(List<AdvertisementDTO> advertisements)
 
     public static GetAdvertisementResponseDTO of(List<Advertisement> advertisements) {
         List<AdvertisementDTO> advertisementDTOs = advertisements.stream()
-                .map(ad -> AdvertisementDTO.of(ad.getId(), ad.getPosition(), ad.getImageUrl()))
+                .map(ad -> AdvertisementDTO.of(ad.getId(), ad.getPosition(), ad.getImageUrl(), ad.getLinkUrl()))
                 .toList();
 
         return new GetAdvertisementResponseDTO(advertisementDTOs);
@@ -17,10 +17,11 @@ public record GetAdvertisementResponseDTO(List<AdvertisementDTO> advertisements)
     public record AdvertisementDTO(
             Long id,
             Position position,
-            String imageUrl
+            String imageUrl,
+            String linkUrl
     ) {
-        public static AdvertisementDTO of(Long id, Position position, String imageUrl) {
-            return new AdvertisementDTO(id, position, imageUrl);
+        public static AdvertisementDTO of(Long id, Position position, String imageUrl, String linkUrl) {
+            return new AdvertisementDTO(id, position, imageUrl, linkUrl);
         }
     }
 

--- a/src/main/java/kr/tennispark/point/user/infrastrurcture/repository/PointHistoryRepository.java
+++ b/src/main/java/kr/tennispark/point/user/infrastrurcture/repository/PointHistoryRepository.java
@@ -27,6 +27,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             AND ph.amount > 0 
             GROUP BY ph.point.member 
             ORDER BY SUM(ph.amount) DESC
+            LIMIT 1
             """)
     Optional<Member> findTopEarner(LocalDateTime start, LocalDateTime end);
 
@@ -36,7 +37,8 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             WHERE ph.createdAt BETWEEN :start AND :end 
             AND ph.amount < 0 
             GROUP BY ph.point.member 
-            ORDER BY SUM(ph.amount) ASC
+            ORDER BY SUM(ph.amount) ASC 
+            LIMIT 1
             """)
     Optional<Member> findTopSpender(LocalDateTime start, LocalDateTime end);
 


### PR DESCRIPTION
- 월 별 통계 쿼리 조회 시, 항상 하나의 회원만 조회 하도록 쿼리 수정