### PR TITLE
[Refactor] 알림 전송 시, Deprecated된 메서드 대신 sendEachForMulticast 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // firebase
-    implementation 'com.google.firebase:firebase-admin:9.1.1'
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/tennispark/notification/application/FcmMessageService.java
+++ b/src/main/java/kr/tennispark/notification/application/FcmMessageService.java
@@ -53,7 +53,7 @@ public class FcmMessageService {
                 .build();
 
         try {
-            BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(message);
+            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
 
             if (response.getFailureCount() > 0) {
                 List<SendResponse> failedResponses = response.getResponses().stream()


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #34 

## 🔧 작업 내용
- 알림 전송 시, Deprecated된 메서드 대신 sendEachForMulticast 사용
- 기존 sendMulticast 메서드 사용 시 API 호출 엔드포인트가 존재하지 않아 404에러 발생

## 💬 기타 사항
