### PR TITLE
[Feature] 회원 탈퇴 구현

### DIFF
--- a/src/main/java/kr/tennispark/activity/common/domain/ActivityApplication.java
+++ b/src/main/java/kr/tennispark/activity/common/domain/ActivityApplication.java
@@ -70,5 +70,16 @@ public class ActivityApplication extends BaseEntity {
         }
         this.applicationStatus = nextStatus;
     }
+
+    public void cancelByWithdrawal() {
+        if (!this.applicationStatus.isCounted()) {
+            delete();
+            return;
+        }
+
+        activity.decrementParticipant();
+        this.applicationStatus = ApplicationStatus.CANCELED;
+        delete();
+    }
 }
 

--- a/src/main/java/kr/tennispark/activity/user/infrastructure/repository/UserActivityApplicationRepository.java
+++ b/src/main/java/kr/tennispark/activity/user/infrastructure/repository/UserActivityApplicationRepository.java
@@ -1,12 +1,14 @@
 package kr.tennispark.activity.user.infrastructure.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import kr.tennispark.activity.common.domain.Activity;
 import kr.tennispark.activity.common.domain.ActivityApplication;
 import kr.tennispark.activity.common.domain.enums.ApplicationStatus;
 import kr.tennispark.members.common.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,4 +23,13 @@ public interface UserActivityApplicationRepository extends JpaRepository<Activit
                     WHERE aa.createdAt BETWEEN :start AND :end
             """)
     int countDistinctMemberIdByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+            SELECT aa
+            FROM ActivityApplication aa
+            WHERE aa.member = :member
+              AND aa.status = true
+              AND aa.applicationStatus IN ('PENDING','APPROVED')
+            """)
+    List<ActivityApplication> findActiveByMember(@Param("member") Member member);
 }

--- a/src/main/java/kr/tennispark/members/common/domain/entity/Member.java
+++ b/src/main/java/kr/tennispark/members/common/domain/entity/Member.java
@@ -133,4 +133,12 @@ public class Member extends BaseEntity {
             this.fcmToken = null;
         }
     }
+
+    public void withdraw() {
+        if (!isStatus()) {
+            return;
+        }
+        delete();
+        point.delete();
+    }
 }

--- a/src/main/java/kr/tennispark/members/user/application/service/MemberService.java
+++ b/src/main/java/kr/tennispark/members/user/application/service/MemberService.java
@@ -65,13 +65,13 @@ public class MemberService {
     }
 
     @Transactional
-    public void withdraw(Long memberId) {
-        Member member = memberRepository.getById(memberId);
+    public void withdraw(Member member) {
+        Member dbMember = memberRepository.getById(member.getId());
 
-        member.withdraw();
+        dbMember.withdraw();
 
         List<ActivityApplication> apps =
-                applicationRepository.findActiveByMember(member);
+                applicationRepository.findActiveByMember(dbMember);
 
         apps.forEach(ActivityApplication::cancelByWithdrawal);
     }

--- a/src/main/java/kr/tennispark/members/user/application/service/MemberService.java
+++ b/src/main/java/kr/tennispark/members/user/application/service/MemberService.java
@@ -1,5 +1,8 @@
 package kr.tennispark.members.user.application.service;
 
+import java.util.List;
+import kr.tennispark.activity.common.domain.ActivityApplication;
+import kr.tennispark.activity.user.infrastructure.repository.UserActivityApplicationRepository;
 import kr.tennispark.match.common.domain.entity.enums.MatchOutcome;
 import kr.tennispark.match.common.infrastructure.repository.MatchPointRankingRepository;
 import kr.tennispark.match.user.infrastructure.repository.UserMatchParticipationRepository;
@@ -20,6 +23,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MatchPointRankingRepository rankingRepository;
     private final UserMatchParticipationRepository participationRepository;
+    private final UserActivityApplicationRepository applicationRepository;
 
     @Transactional
     public void createMember(RegisterMemberRequest request) {
@@ -58,5 +62,17 @@ public class MemberService {
     public void updateFcmToken(Member member, String fcmToken) {
         member.updateFcmToken(fcmToken);
         memberRepository.save(member);
+    }
+
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = memberRepository.getById(memberId);
+
+        member.withdraw();
+
+        List<ActivityApplication> apps =
+                applicationRepository.findActiveByMember(member);
+
+        apps.forEach(ActivityApplication::cancelByWithdrawal);
     }
 }

--- a/src/main/java/kr/tennispark/members/user/application/service/MemberService.java
+++ b/src/main/java/kr/tennispark/members/user/application/service/MemberService.java
@@ -11,6 +11,7 @@ import kr.tennispark.members.common.domain.entity.vo.Phone;
 import kr.tennispark.members.user.infrastructure.repository.MemberRepository;
 import kr.tennispark.members.user.presentation.dto.request.RegisterMemberRequest;
 import kr.tennispark.members.user.presentation.dto.response.GetMemberMatchRecordResponse;
+import kr.tennispark.membership.infrastructure.repository.MembershipRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ public class MemberService {
     private final MatchPointRankingRepository rankingRepository;
     private final UserMatchParticipationRepository participationRepository;
     private final UserActivityApplicationRepository applicationRepository;
+    private final MembershipRepository membershipRepository;
 
     @Transactional
     public void createMember(RegisterMemberRequest request) {
@@ -69,6 +71,9 @@ public class MemberService {
         Member dbMember = memberRepository.getById(member.getId());
 
         dbMember.withdraw();
+
+        membershipRepository.findByMember(member)
+                .ifPresent(membershipRepository::delete);
 
         List<ActivityApplication> apps =
                 applicationRepository.findActiveByMember(dbMember);

--- a/src/main/java/kr/tennispark/members/user/presentation/controller/UserMemberController.java
+++ b/src/main/java/kr/tennispark/members/user/presentation/controller/UserMemberController.java
@@ -10,6 +10,7 @@ import kr.tennispark.members.user.presentation.dto.response.GetMemberMatchRecord
 import kr.tennispark.members.user.presentation.dto.response.GetMyNameResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserMemberController {
 
     private final MemberService memberService;
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResult<String>> withdrawMember(@LoginMember Member member) {
+        memberService.withdraw(member);
+        return ResponseEntity.ok(ApiUtils.success());
+    }
 
     @GetMapping("/name/me")
     public ResponseEntity<ApiResult<GetMyNameResponse>> getMyName(@LoginMember Member member) {

--- a/src/main/java/kr/tennispark/membership/infrastructure/repository/MembershipRepository.java
+++ b/src/main/java/kr/tennispark/membership/infrastructure/repository/MembershipRepository.java
@@ -1,5 +1,6 @@
 package kr.tennispark.membership.infrastructure.repository;
 
+import java.util.Optional;
 import kr.tennispark.members.common.domain.entity.Member;
 import kr.tennispark.membership.common.domain.entity.Membership;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
     boolean existsByMember(Member member);
+
+    Optional<Membership> findByMember(Member member);
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #109 
## 🔧 작업 내용
회원 탈퇴 기능 구현
## 💬 기타 사항
회원 탈퇴할 때 Point를 삭제하면서 PointHistory까지 같이 삭제되게 전이를 걸면, 쿼리가 너무 많이 나가서 부담될 것 같더라고요.
게다가 PointHistory는 다른 곳에서 사용되는 데이터도 아니라서, 굳이 논리 삭제까지 전이시킬 필요는 없겠다고 판단했습니다.