### PR TITLE
[Feature] 게임 코트 유형 Enum 프론트와 통일

### DIFF
--- a/src/main/java/kr/tennispark/activity/common/domain/enums/ActivityName.java
+++ b/src/main/java/kr/tennispark/activity/common/domain/enums/ActivityName.java
@@ -1,18 +1,16 @@
 package kr.tennispark.activity.common.domain.enums;
 
 import kr.tennispark.activity.common.domain.exception.InvalidActivityCombinationException;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 public enum ActivityName {
 
     // 일반 활동
     GAME(ActivityType.GENERAL),
-    GAME_CHALLENGE(ActivityType.GENERAL),
+    CHALLENGE(ActivityType.GENERAL),
     RALLY(ActivityType.GENERAL),
-    GAME_STUDY(ActivityType.GENERAL),
+    STUDY(ActivityType.GENERAL),
     BEGINNER(ActivityType.GENERAL),
 
     // 아카데미


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #115 

## 🔧 작업 내용
- 게임 코트 유형 Enum 프론트와 통일
    -  "게임스터디" : "GAME_STUDY" → "STUDY"
    - "게임도전" : "GAME_CHALLENGE" → "CHALLENGE"

## 💬 기타 사항
- PR 머지 전 DB 수정 필요