### PR TITLE
[Feature] 회원 탈퇴 시 phone_number 유니크 제약 회피를 위한 마스킹 처리 적용

### DIFF
--- a/src/main/java/kr/tennispark/members/common/domain/entity/Member.java
+++ b/src/main/java/kr/tennispark/members/common/domain/entity/Member.java
@@ -138,6 +138,7 @@ public class Member extends BaseEntity {
         if (!isStatus()) {
             return;
         }
+        this.phone = this.phone.withdrawMasked(this.getId());
         delete();
         point.delete();
     }

--- a/src/main/java/kr/tennispark/members/common/domain/entity/vo/Phone.java
+++ b/src/main/java/kr/tennispark/members/common/domain/entity/vo/Phone.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Phone {
 
+    private static final String MASKED_PHONE_SUFFIX = "_DELETED_";
     private static final Pattern PHONE_PATTERN = Pattern.compile("^010\\d{8}$");
 
     @Column(name = "phone_number", nullable = false, unique = true)
@@ -29,5 +30,9 @@ public class Phone {
             throw new InvalidMemberException("휴대폰 번호 형식이 올바르지 않습니다. 예: 01012345678");
         }
         return new Phone(value);
+    }
+
+    public Phone withdrawMasked(Long memberId) {
+        return new Phone(this.number + MASKED_PHONE_SUFFIX + memberId);
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #123 

## 🔧 작업 내용
- 회원 탈퇴 후 동일 휴대폰 번호로 재가입 시 UNIQUE 제약 조건 충돌 발생
    - 기존 soft delete 방식 (status = false) 유지
- 탈퇴 시 기존 휴대폰 번호에 마스킹을 적용하여 유니크 제약을 회피하도록 처리
    - 예: 01012345678 → 01012345678_DELETED_{id} 또는 __DELETED__{UUID}
- 마스킹된 번호는 추후 복구 등을 고려해 추적 가능하게 구성
- 유니크 제약 조건(UNIQUE)은 그대로 유지
## 💬 기타 사항
