### PR TITLE
[Feature] 활동 생성 기준 변경

### DIFF
--- a/src/main/java/kr/tennispark/activity/admin/presentation/dto/response/GetActivityApplicantResponseDTO.java
+++ b/src/main/java/kr/tennispark/activity/admin/presentation/dto/response/GetActivityApplicantResponseDTO.java
@@ -9,7 +9,7 @@ public record GetActivityApplicantResponseDTO(Page<ActivityApplicantDTO> applica
     public static GetActivityApplicantResponseDTO of(Page<ActivityApplication> applicants) {
         Page<ActivityApplicantDTO> applicantDTOs = applicants.map(applicant ->
                 ActivityApplicantDTO.of(
-                        applicant.getId(),
+                        applicant.getMember().getId(),
                         applicant.getMember().getName(),
                         applicant.getMember().getPhone().getNumber(),
                         applicant.getMember().getMemberShipType(),

--- a/src/main/java/kr/tennispark/activity/common/domain/vo/WeekPeriod.java
+++ b/src/main/java/kr/tennispark/activity/common/domain/vo/WeekPeriod.java
@@ -9,11 +9,11 @@ import kr.tennispark.activity.common.domain.enums.Days;
 public record WeekPeriod(LocalDate start) {
 
     private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
-    private static final DayOfWeek WEEK_START = DayOfWeek.FRIDAY;
+    private static final DayOfWeek WEEK_START = DayOfWeek.MONDAY;
 
     public static WeekPeriod current() {
         LocalDate today = LocalDate.now(ZONE_ID);
-        LocalDate start = today.with(TemporalAdjusters.previousOrSame(WEEK_START));
+        LocalDate start = today.with(TemporalAdjusters.next(WEEK_START));
         return new WeekPeriod(start);
     }
 


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #132 

## 🔧 작업 내용
- PO님께서 요구한 변경사항입니다!
- 모집 날짜를 차주 기준으로 변경
- 7월 11일(금) 모집은 7월 14일(월) ~ 7월 20일(일) 기간을 모집 해야 하지만, 현재는 11일부터 그 다음 주 금요일까지 활동을 생성하는 상황
- 활동 스케줄러가 그 다음 주 월~일 기간의 활동을 생성 하도록 기준 변경

## 💬 기타 사항
- IOS측 추가 요구사항 반영
- https://docs.google.com/spreadsheets/d/1dp_geC2xIxdNZCiOSd-Ed2Ro8y3B6erWbn4subbD8mI/edit?gid=565266550#gid=565266550 
- 해당 PR은 위 링크의 22번 이슈를 해결한 것
