### PR TITLE
[Feature] 활동 도메인에 승인된 신청 수 필드 추가

### DIFF
--- a/src/main/java/kr/tennispark/activity/admin/presentation/dto/response/GetActivityApplicationResponseDTO.java
+++ b/src/main/java/kr/tennispark/activity/admin/presentation/dto/response/GetActivityApplicationResponseDTO.java
@@ -15,7 +15,7 @@ public record GetActivityApplicationResponseDTO(
                         activity.getCourtName(),
                         activity.getScheduledTime().getBeginAt(),
                         activity.getScheduledTime().getEndAt(),
-                        activity.getParticipantCount(),
+                        activity.getApplicantCount(),
                         activity.getCapacity()
                 )
         );

--- a/src/main/java/kr/tennispark/activity/common/domain/Activity.java
+++ b/src/main/java/kr/tennispark/activity/common/domain/Activity.java
@@ -46,6 +46,9 @@ public class Activity extends BaseEntity {
     private Integer participantCount = 0;
 
     @Column(nullable = false)
+    private Integer applicantCount = 0;
+
+    @Column(nullable = false)
     private Integer capacity;
 
     @Embedded
@@ -72,6 +75,7 @@ public class Activity extends BaseEntity {
                         template.getTime().getEndAt()
                 ),
                 0,
+                0,
                 template.getCapacity(),
                 template.getPlace(),
                 template.getType(),
@@ -92,6 +96,10 @@ public class Activity extends BaseEntity {
             throw new ParticipantUnderflowException();
         }
         this.participantCount--;
+    }
+
+    public void incrementApplicant() {
+        this.applicantCount++;
     }
 }
 

--- a/src/main/java/kr/tennispark/activity/user/application/service/ActivityCommandService.java
+++ b/src/main/java/kr/tennispark/activity/user/application/service/ActivityCommandService.java
@@ -33,6 +33,7 @@ public class ActivityCommandService {
 
     private void apply(Member member, Long activityId, ActivityType type) {
         Activity activity = loadAndLockActivity(activityId, type);
+        activity.incrementApplicant();
         preventDuplicate(member, activity);
         recordApplication(member, activity);
     }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #144 

## 🔧 작업 내용
- 관리자 페이지 내 활동 신청 조회 시에는 실제 신청 갯수만 보여줌
- 사용자가 활동 신청 시에는 실제로 승인된 활동 신청 갯수만 보여줌
- 이를 위해 활동 도메인 내 승인된 신청 수 필드 추가

## 💬 기타 사항
- 활동 신청 자체는 아예 삭제되는 경우는 없어서 신청자 수 감소 로직은 따로 구현하지 않았습니다.