### PR TITLE
[Feature] 경기 승리 시 포인트 지급 로직 임시 비활성화

### DIFF
--- a/src/main/java/kr/tennispark/match/admin/application/impl/MatchResultServiceImpl.java
+++ b/src/main/java/kr/tennispark/match/admin/application/impl/MatchResultServiceImpl.java
@@ -16,7 +16,6 @@ import kr.tennispark.members.common.domain.entity.Member;
 import kr.tennispark.members.common.domain.exception.NoSuchMemberException;
 import kr.tennispark.members.user.infrastructure.repository.MemberRepository;
 import kr.tennispark.point.common.application.service.PointService;
-import kr.tennispark.point.common.domain.entity.enums.PointReason;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -82,11 +81,12 @@ public class MatchResultServiceImpl implements MatchResultService {
     private void rewardWinningTeam(MatchOutcome outcome, List<Member> members) {
         processMatchPoint(members, outcome);
 
-        for (Member member : members) {
-            if (outcome == MatchOutcome.WIN) {
-                pointService.applyPoint(member, WIN_POINT, PointReason.WIN_MATCH, "매치 승리");
-            }
-        }
+        // 요청으로 인해 포인트 지급 로직이 일시적으로 주석 처리됨
+//        for (Member member : members) {
+//            if (outcome == MatchOutcome.WIN) {
+//                pointService.applyPoint(member, WIN_POINT, PointReason.WIN_MATCH, "매치 승리");
+//            }
+//        }
     }
 
 

--- a/src/main/java/kr/tennispark/match/common/domain/entity/association/MatchParticipation.java
+++ b/src/main/java/kr/tennispark/match/common/domain/entity/association/MatchParticipation.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.SQLRestriction;
 public class MatchParticipation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #165 

## 🔧 작업 내용
- 경기 승리 시 포인트 지급 로직 임시 비활성화 (클라이언트 요청)
- match_pariticipation 테이블 내 member_id 컬럼 null 임시 허용
    - 미가입 된 회원의 경기 결과를 등록해야 하는 상황

## 💬 기타 사항
