### PR TITLE
[Fix] 참여자 알림 발송 시 승인 상태의 신청자만 반영

### DIFF
--- a/src/main/java/kr/tennispark/common/scheduler/SendActivityNotificationScheduler.java
+++ b/src/main/java/kr/tennispark/common/scheduler/SendActivityNotificationScheduler.java
@@ -46,6 +46,7 @@ public class SendActivityNotificationScheduler {
 
                 List<String> participantNames = adminActivityApplicationRepository.findAllByActivity(activity)
                         .stream()
+                        .filter(app -> app.getApplicationStatus().isAccepted())
                         .filter(app -> !app.isDeleted() && !app.getMember().isDeleted())
                         .map(app -> app.getMember().getName())
                         .toList();


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #177 
## 🔧 작업 내용

## 💬 기타 사항
